### PR TITLE
fix: test-utils after fn

### DIFF
--- a/packages/test-utils/spec/test-utils.spec.ts
+++ b/packages/test-utils/spec/test-utils.spec.ts
@@ -1,5 +1,5 @@
-import testUtils from "../";
 import bus from "@fruster/bus";
+import testUtils from "../";
 
 if (!process.env.CI) {
 	describe("Fruster test utils", () => {
@@ -42,31 +42,96 @@ if (!process.env.CI) {
 				});
 		});
 
-		xit("should start, stop NATS server, connect fruster bus, connect to mongodb and start a service", (done) => {
-			testUtils
-				.start({
-					bus: bus,
-					mongoUrl:
-						"mongodb://localhost:27017/fruster-test-util-test",
-					service: {
-						start: (busAddress, mongoUrl) => {
-							expect(busAddress).toMatch("nats://");
-							expect(mongoUrl).toBe(
-								"mongodb://localhost:27017/fruster-test-util-test"
-							);
-							return Promise.resolve();
-						},
+		it("should start, stop NATS server, connect fruster bus, connect to mongodb and start a service", async () => {
+			const connection = await testUtils.start({
+				bus: bus,
+				mongoUrl: "mongodb://localhost:27017/fruster-test-util-test",
+				service: {
+					start: (busAddress, mongoUrl) => {
+						expect(busAddress).toMatch("nats://");
+						expect(mongoUrl).toBe(
+							"mongodb://localhost:27017/fruster-test-util-test"
+						);
+						return Promise.resolve();
 					},
-				})
-				.then((connection) => {
-					expect(connection.server).toBeDefined();
-					expect(connection.natsClient).toBeDefined();
-					expect(connection.db).toBeDefined();
+				},
+			});
 
-					testUtils.close(connection);
+			expect(connection.server).toBeDefined();
+			expect(connection.natsClient).toBeDefined();
+			expect(connection.db).toBeDefined();
 
-					done();
-				});
+			testUtils.close(connection);
+		});
+
+		fdescribe("startBeforeEach", () => {
+			/**
+			 * This spec is a bit awkward, but it's the only way to test the
+			 * `beforeStop` and `afterStart` hooks.
+			 *
+			 * Run the whole suite (this "describe") in order for it to work.
+			 */
+			let beforeStopInvoked = false;
+			let afterStartInvoked = false;
+
+			testUtils.startBeforeEach({
+				bus: bus,
+				mongoUrl: "mongodb://localhost:27017/fruster-test-util-test",
+				service: {
+					start: (busAddress, mongoUrl) => {
+						console.log("Starting fake service");
+						expect(busAddress).toMatch("nats://");
+						expect(mongoUrl).toBe(
+							"mongodb://localhost:27017/fruster-test-util-test"
+						);
+						return Promise.resolve();
+					},
+				},
+				afterStart: async (connection) => {
+					afterStartInvoked = true;
+
+					const doc = await connection.db
+						.collection("test")
+						.findOne({ test: "test" });
+
+					expect(doc).toBeNull();
+
+					await connection.db
+						.collection("test")
+						.insertOne({ test: "test" });
+
+					console.log("afterStart() completed");
+				},
+				beforeStop: async (connection) => {
+					beforeStopInvoked = true;
+					const doc = await connection.db
+						.collection("test")
+						.findOne({ test: "test" });
+					expect(doc).toBeDefined();
+
+					console.log("beforeStop() completed");
+				},
+				dropDatabase: true,
+			});
+
+			it("should invoked startBeforeEach", async () => {
+				console.log(
+					"First run: afterStart should have been invoked but not beforeStop"
+				);
+				expect(afterStartInvoked).toBe(true);
+				expect(beforeStopInvoked).toBe(false);
+			});
+
+			it("should invoked beforeStop", async () => {
+				console.log(
+					"Second run: beforeStop should have been invoked as the previous test has finished"
+				);
+				expect(beforeStopInvoked).toBe(true);
+			});
 		});
 	});
+}
+
+async function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Makes sure beforeStop function works async and removes dropping db by default.