### PR TITLE
feat: add support for Jasmine spec filtering via command-line arguments

### DIFF
--- a/.changeset/fix-workspace-protocol.md
+++ b/.changeset/fix-workspace-protocol.md
@@ -1,0 +1,11 @@
+---
+"@fruster/bus": patch
+"@fruster/decorators": patch
+"@fruster/health": patch
+"@fruster/log": patch
+"@fruster/runner": patch
+"@fruster/test-utils": patch
+"@fruster/ts-transformer": patch
+---
+
+Fix workspace protocol in published packages

--- a/.changeset/jasmine-spec-filtering.md
+++ b/.changeset/jasmine-spec-filtering.md
@@ -1,0 +1,14 @@
+---
+"@fruster/runner": minor
+"@fruster/test-utils": patch
+---
+
+Add support for filtering Jasmine specs via command-line arguments
+
+The fruster-runner now preserves command-line arguments after the entry file, allowing jasmine-runner to receive and forward spec filters to Jasmine's execute() method.
+
+Usage examples:
+- Run specific spec file: `fruster-runner ./spec/support/jasmine-runner.ts spec/CarHandler.spec.ts`
+- Filter by spec name: `fruster-runner ./spec/support/jasmine-runner.ts --filter="should get car"`
+- Use regex patterns: `fruster-runner ./spec/support/jasmine-runner.ts --filter="should get car$"`
+- Combine both: `fruster-runner ./spec/support/jasmine-runner.ts spec/MyHandler.spec.ts --filter="specific test"`

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,16 +2,17 @@
   "mode": "pre",
   "tag": "alpha",
   "initialVersions": {
-    "@fruster/bus": "1.2.0-alpha.0",
-    "@fruster/decorators": "1.2.0-alpha.0",
+    "@fruster/bus": "1.2.0-alpha.1",
+    "@fruster/decorators": "1.2.0-alpha.1",
     "demo-app": "1.2.0-alpha.1",
-    "@fruster/health": "1.2.0-alpha.1",
-    "@fruster/log": "1.2.0-alpha.1",
-    "@fruster/runner": "1.2.0-alpha.1",
-    "@fruster/test-utils": "1.2.0-alpha.1",
-    "@fruster/ts-transformer": "1.2.0-alpha.0"
+    "@fruster/health": "1.2.0-alpha.2",
+    "@fruster/log": "1.2.0-alpha.2",
+    "@fruster/runner": "1.2.0-alpha.2",
+    "@fruster/test-utils": "1.2.0-alpha.2",
+    "@fruster/ts-transformer": "1.2.0-alpha.1"
   },
   "changesets": [
+    "fix-workspace-protocol",
     "jasmine-spec-filtering",
     "migrate-to-pnpm"
   ]

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,18 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@fruster/bus": "1.2.0-alpha.0",
+    "@fruster/decorators": "1.2.0-alpha.0",
+    "demo-app": "1.2.0-alpha.1",
+    "@fruster/health": "1.2.0-alpha.1",
+    "@fruster/log": "1.2.0-alpha.1",
+    "@fruster/runner": "1.2.0-alpha.1",
+    "@fruster/test-utils": "1.2.0-alpha.1",
+    "@fruster/ts-transformer": "1.2.0-alpha.0"
+  },
+  "changesets": [
+    "jasmine-spec-filtering",
+    "migrate-to-pnpm"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,22 +260,43 @@ pnpm changeset
 # 2. Enter pre-release mode
 pnpm changeset pre enter alpha
 # This puts the monorepo in pre-release mode
+# The pre-release identifier (alpha/beta/rc) becomes the npm dist-tag
 
 # 3. Version packages
 pnpm run version-packages
 # Versions will be like: 1.3.0-alpha.0
 
-# 4. Publish with pre-release tag
-pnpm run release --tag next
-# Users install with: pnpm add @fruster/bus@next
+# 4. Commit version changes
+git add .
+git commit -m "chore: version packages (alpha)"
+git push
 
-# 5. Exit pre-release mode when ready for stable release
+# 5. Build and publish packages
+pnpm run build
+pnpm publish -r --tag alpha --no-git-checks
+# IMPORTANT: Use 'pnpm publish -r' instead of 'changeset publish'
+# This ensures workspace:* dependencies are converted to actual versions
+# Users install with: pnpm add @fruster/bus@alpha
+
+# 6. For subsequent alpha releases, create new changesets and repeat steps 3-5
+# Versions will increment automatically (alpha.1, alpha.2, etc.)
+
+# 7. Exit pre-release mode when ready for stable release
 pnpm changeset pre exit
 pnpm run version-packages  # Creates stable versions
-pnpm run release          # Publishes as latest
+git add .
+git commit -m "chore: version packages"
+git push
+pnpm run build
+pnpm publish -r --no-git-checks  # Publishes as latest
 ```
 
 **Common pre-release identifiers:** `alpha`, `beta`, `rc` (release candidate)
+
+**Important Notes:**
+- When in pre-release mode, Changesets automatically uses the pre-release identifier as the npm dist-tag
+- Always use `pnpm publish -r` instead of `changeset publish` to ensure proper workspace protocol conversion
+- The `--no-git-checks` flag allows publishing without git tags (useful for alpha releases)
 
 All packages have `"publishConfig": { "access": "public" }` for npm registry.
 

--- a/packages/bus/CHANGELOG.md
+++ b/packages/bus/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @fruster/bus
+
+## 1.2.0-alpha.1
+
+### Patch Changes
+
+- 824a007: Migrate monorepo from Lerna to pnpm workspaces with Changesets
+
+  This migration brings:
+
+  - Faster dependency installation with pnpm's content-addressable storage
+  - Better disk efficiency through hard-linked packages
+  - Automatic dependency bumping when internal packages change
+  - Modern tooling with active development and maintenance
+  - Improved developer experience with workspace protocol support

--- a/packages/bus/CHANGELOG.md
+++ b/packages/bus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fruster/bus
 
+## 1.2.0-alpha.2
+
+### Patch Changes
+
+- Fix workspace protocol in published packages
+
 ## 1.2.0-alpha.1
 
 ### Patch Changes

--- a/packages/bus/package.json
+++ b/packages/bus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fruster/bus",
-	"version": "1.2.0-alpha.0",
+	"version": "1.2.0-alpha.1",
 	"description": "NATS message bus helper for Fruster micro services",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/bus/package.json
+++ b/packages/bus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fruster/bus",
-	"version": "1.2.0-alpha.1",
+	"version": "1.2.0-alpha.2",
 	"description": "NATS message bus helper for Fruster micro services",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/decorators/CHANGELOG.md
+++ b/packages/decorators/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fruster/decorators
 
+## 1.2.0-alpha.2
+
+### Patch Changes
+
+- Fix workspace protocol in published packages
+
 ## 1.2.0-alpha.1
 
 ### Patch Changes

--- a/packages/decorators/CHANGELOG.md
+++ b/packages/decorators/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @fruster/decorators
+
+## 1.2.0-alpha.1
+
+### Patch Changes
+
+- 824a007: Migrate monorepo from Lerna to pnpm workspaces with Changesets
+
+  This migration brings:
+
+  - Faster dependency installation with pnpm's content-addressable storage
+  - Better disk efficiency through hard-linked packages
+  - Automatic dependency bumping when internal packages change
+  - Modern tooling with active development and maintenance
+  - Improved developer experience with workspace protocol support

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fruster/decorators",
-	"version": "1.2.0-alpha.0",
+	"version": "1.2.0-alpha.1",
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"publishConfig": {

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fruster/decorators",
-	"version": "1.2.0-alpha.1",
+	"version": "1.2.0-alpha.2",
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"publishConfig": {

--- a/packages/demo-app/spec/support/jasmine-runner.ts
+++ b/packages/demo-app/spec/support/jasmine-runner.ts
@@ -10,6 +10,27 @@ let jRunner = new Jasmine({});
 jRunner.configureDefaultReporter({ print: noop });
 jasmine.getEnv().addReporter(new SpecReporter());
 jRunner.loadConfigFile("./spec/support/jasmine.json");
-jRunner.execute();
+
+// Parse command line arguments
+// Usage: fruster-runner jasmine-runner.ts [spec-files...] [--filter=pattern]
+const args = process.argv.slice(2);
+let specFiles: string[] | undefined;
+let filterString: string | undefined;
+
+for (let i = 0; i < args.length; i++) {
+	const arg = args[i];
+
+	if (arg.startsWith("--filter=")) {
+		filterString = arg.substring("--filter=".length);
+	} else if (arg === "--filter") {
+		filterString = args[++i];
+	} else if (!arg.startsWith("--")) {
+		// Treat as spec file path
+		if (!specFiles) specFiles = [];
+		specFiles.push(arg);
+	}
+}
+
+jRunner.execute(specFiles, filterString);
 
 export default () => {};

--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @fruster/health
+
+## 1.2.0-alpha.2
+
+### Patch Changes
+
+- 824a007: Migrate monorepo from Lerna to pnpm workspaces with Changesets
+
+  This migration brings:
+
+  - Faster dependency installation with pnpm's content-addressable storage
+  - Better disk efficiency through hard-linked packages
+  - Automatic dependency bumping when internal packages change
+  - Modern tooling with active development and maintenance
+  - Improved developer experience with workspace protocol support

--- a/packages/health/CHANGELOG.md
+++ b/packages/health/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fruster/health
 
+## 1.2.0-alpha.3
+
+### Patch Changes
+
+- Fix workspace protocol in published packages
+
 ## 1.2.0-alpha.2
 
 ### Patch Changes

--- a/packages/health/package.json
+++ b/packages/health/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fruster/health",
-	"version": "1.2.0-alpha.2",
+	"version": "1.2.0-alpha.3",
 	"description": "Health checks for Fruster services",
 	"types": "dist/index.d.ts",
 	"main": "dist/index.js",

--- a/packages/health/package.json
+++ b/packages/health/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fruster/health",
-	"version": "1.2.0-alpha.1",
+	"version": "1.2.0-alpha.2",
 	"description": "Health checks for Fruster services",
 	"types": "dist/index.d.ts",
 	"main": "dist/index.js",

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fruster/log
 
+## 1.2.0-alpha.3
+
+### Patch Changes
+
+- Fix workspace protocol in published packages
+
 ## 1.2.0-alpha.2
 
 ### Patch Changes

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @fruster/log
+
+## 1.2.0-alpha.2
+
+### Patch Changes
+
+- 824a007: Migrate monorepo from Lerna to pnpm workspaces with Changesets
+
+  This migration brings:
+
+  - Faster dependency installation with pnpm's content-addressable storage
+  - Better disk efficiency through hard-linked packages
+  - Automatic dependency bumping when internal packages change
+  - Modern tooling with active development and maintenance
+  - Improved developer experience with workspace protocol support

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruster/log",
-  "version": "1.2.0-alpha.2",
+  "version": "1.2.0-alpha.3",
   "description": "Logger for Fruster (micro) services",
   "main": "index.js",
   "private": false,

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruster/log",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "description": "Logger for Fruster (micro) services",
   "main": "index.js",
   "private": false,

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,0 +1,33 @@
+# @fruster/runner
+
+## 1.2.0-alpha.2
+
+### Minor Changes
+
+- e87a82f: Add support for filtering Jasmine specs via command-line arguments
+
+  The fruster-runner now preserves command-line arguments after the entry file, allowing jasmine-runner to receive and forward spec filters to Jasmine's execute() method.
+
+  Usage examples:
+
+  - Run specific spec file: `fruster-runner ./spec/support/jasmine-runner.ts spec/CarHandler.spec.ts`
+  - Filter by spec name: `fruster-runner ./spec/support/jasmine-runner.ts --filter="should get car"`
+  - Use regex patterns: `fruster-runner ./spec/support/jasmine-runner.ts --filter="should get car$"`
+  - Combine both: `fruster-runner ./spec/support/jasmine-runner.ts spec/MyHandler.spec.ts --filter="specific test"`
+
+### Patch Changes
+
+- 824a007: Migrate monorepo from Lerna to pnpm workspaces with Changesets
+
+  This migration brings:
+
+  - Faster dependency installation with pnpm's content-addressable storage
+  - Better disk efficiency through hard-linked packages
+  - Automatic dependency bumping when internal packages change
+  - Modern tooling with active development and maintenance
+  - Improved developer experience with workspace protocol support
+
+- Updated dependencies [824a007]
+  - @fruster/bus@1.2.0-alpha.1
+  - @fruster/log@1.2.0-alpha.2
+  - @fruster/ts-transformer@1.2.0-alpha.1

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @fruster/runner
 
+## 1.2.0-alpha.3
+
+### Patch Changes
+
+- Fix workspace protocol in published packages
+- Updated dependencies
+  - @fruster/bus@1.2.0-alpha.2
+  - @fruster/log@1.2.0-alpha.3
+  - @fruster/ts-transformer@1.2.0-alpha.2
+
 ## 1.2.0-alpha.2
 
 ### Minor Changes

--- a/packages/runner/lib/runner.js
+++ b/packages/runner/lib/runner.js
@@ -81,6 +81,10 @@ function main(args) {
       transformers,
     });
 
+    // Preserve additional arguments after entry file for the script to use
+    // Remove node, fruster-runner, and entry file from argv
+    process.argv = [process.argv[0], entryFile, ...args.slice(3)];
+
     require(path.join(process.cwd(), entryFile));
   }
 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruster/runner",
-  "version": "1.2.0-alpha.2",
+  "version": "1.2.0-alpha.3",
   "description": "Runner used to run fruster services. Applies typescript transformations to parse schemas etc before service is started.",
   "homepage": "https://github.com/FrostDigital/fruster#readme",
   "license": "MIT",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruster/runner",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "description": "Runner used to run fruster services. Applies typescript transformations to parse schemas etc before service is started.",
   "homepage": "https://github.com/FrostDigital/fruster#readme",
   "license": "MIT",

--- a/packages/test-utils/CHANGELOG.md
+++ b/packages/test-utils/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @fruster/test-utils
 
+## 1.2.0-alpha.3
+
+### Patch Changes
+
+- Fix workspace protocol in published packages
+- Updated dependencies
+  - @fruster/bus@1.2.0-alpha.2
+
 ## 1.2.0-alpha.2
 
 ### Patch Changes

--- a/packages/test-utils/CHANGELOG.md
+++ b/packages/test-utils/CHANGELOG.md
@@ -1,0 +1,29 @@
+# @fruster/test-utils
+
+## 1.2.0-alpha.2
+
+### Patch Changes
+
+- e87a82f: Add support for filtering Jasmine specs via command-line arguments
+
+  The fruster-runner now preserves command-line arguments after the entry file, allowing jasmine-runner to receive and forward spec filters to Jasmine's execute() method.
+
+  Usage examples:
+
+  - Run specific spec file: `fruster-runner ./spec/support/jasmine-runner.ts spec/CarHandler.spec.ts`
+  - Filter by spec name: `fruster-runner ./spec/support/jasmine-runner.ts --filter="should get car"`
+  - Use regex patterns: `fruster-runner ./spec/support/jasmine-runner.ts --filter="should get car$"`
+  - Combine both: `fruster-runner ./spec/support/jasmine-runner.ts spec/MyHandler.spec.ts --filter="specific test"`
+
+- 824a007: Migrate monorepo from Lerna to pnpm workspaces with Changesets
+
+  This migration brings:
+
+  - Faster dependency installation with pnpm's content-addressable storage
+  - Better disk efficiency through hard-linked packages
+  - Automatic dependency bumping when internal packages change
+  - Modern tooling with active development and maintenance
+  - Improved developer experience with workspace protocol support
+
+- Updated dependencies [824a007]
+  - @fruster/bus@1.2.0-alpha.1

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fruster/test-utils",
-	"version": "1.2.0-alpha.2",
+	"version": "1.2.0-alpha.3",
 	"types": "dist/index.d.ts",
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fruster/test-utils",
-	"version": "1.2.0-alpha.1",
+	"version": "1.2.0-alpha.2",
 	"types": "dist/index.d.ts",
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/test-utils/spec/support/jasmine-runner.ts
+++ b/packages/test-utils/spec/support/jasmine-runner.ts
@@ -10,6 +10,27 @@ let jRunner = new Jasmine({});
 jRunner.configureDefaultReporter({ print: noop });
 jasmine.getEnv().addReporter(new SpecReporter());
 jRunner.loadConfigFile("./spec/support/jasmine.json");
-jRunner.execute();
+
+// Parse command line arguments
+// Usage: fruster-runner jasmine-runner.ts [spec-files...] [--filter=pattern]
+const args = process.argv.slice(2);
+let specFiles: string[] | undefined;
+let filterString: string | undefined;
+
+for (let i = 0; i < args.length; i++) {
+	const arg = args[i];
+
+	if (arg.startsWith("--filter=")) {
+		filterString = arg.substring("--filter=".length);
+	} else if (arg === "--filter") {
+		filterString = args[++i];
+	} else if (!arg.startsWith("--")) {
+		// Treat as spec file path
+		if (!specFiles) specFiles = [];
+		specFiles.push(arg);
+	}
+}
+
+jRunner.execute(specFiles, filterString);
 
 export default () => {};

--- a/packages/ts-transformer/CHANGELOG.md
+++ b/packages/ts-transformer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fruster/ts-transformer
 
+## 1.2.0-alpha.2
+
+### Patch Changes
+
+- Fix workspace protocol in published packages
+
 ## 1.2.0-alpha.1
 
 ### Patch Changes

--- a/packages/ts-transformer/CHANGELOG.md
+++ b/packages/ts-transformer/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @fruster/ts-transformer
+
+## 1.2.0-alpha.1
+
+### Patch Changes
+
+- 824a007: Migrate monorepo from Lerna to pnpm workspaces with Changesets
+
+  This migration brings:
+
+  - Faster dependency installation with pnpm's content-addressable storage
+  - Better disk efficiency through hard-linked packages
+  - Automatic dependency bumping when internal packages change
+  - Modern tooling with active development and maintenance
+  - Improved developer experience with workspace protocol support

--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruster/ts-transformer",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "description": "",
   "main": "dist/transformers/fruster-transformer.js",
   "scripts": {

--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruster/ts-transformer",
-  "version": "1.2.0-alpha.0",
+  "version": "1.2.0-alpha.1",
   "description": "",
   "main": "dist/transformers/fruster-transformer.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Added support for filtering Jasmine specs via command-line arguments in fruster-runner
- Modified fruster-runner to preserve arguments after the entry file
- Updated jasmine-runner in demo-app and test-utils to parse and forward spec filters

## What's Changed
- **packages/runner/lib/runner.js**: Preserve `process.argv` arguments after entry file
- **packages/demo-app/spec/support/jasmine-runner.ts**: Parse CLI args and forward to Jasmine's `execute()` method
- **packages/test-utils/spec/support/jasmine-runner.ts**: Same updates for consistency
- **Added changeset**: Documents the feature for future changelog

## Usage Examples

Run all specs:
```bash
fruster-runner ./spec/support/jasmine-runner.ts
```

Run specific spec file:
```bash
fruster-runner ./spec/support/jasmine-runner.ts spec/CarHandler.spec.ts
```

Filter specs by name:
```bash
fruster-runner ./spec/support/jasmine-runner.ts --filter="should get car"
```

Filter with regex pattern:
```bash
fruster-runner ./spec/support/jasmine-runner.ts --filter="should get car$"
```

Combine spec file and filter:
```bash
fruster-runner ./spec/support/jasmine-runner.ts spec/CarHandler.spec.ts --filter="fail"
```

## Test plan
- [x] Verified all tests pass without arguments
- [x] Tested filtering by partial spec name
- [x] Tested filtering with regex patterns
- [x] Tested running specific spec files
- [x] Tested combining spec files and filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)